### PR TITLE
Disallow __proto__ assignment

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,6 +55,10 @@ Reference.createFromPath = function(pointer, path) {
   var reference = new Reference(pointer);
   path = path.split('.');
   path.forEach(function(field) {
+    if (field === '__proto__') {
+      throw new Error('Cannot assign reference to prototype')
+    }
+
     var isNumber = checkIfStringIsNumber(field);
     var hasParent = reference.getParent() ? true : false;
     if (isNumber) {

--- a/test/index.js
+++ b/test/index.js
@@ -42,6 +42,14 @@ describe('#set', function() {
     obj.a[1].should.equal('B');
     obj.a[2].should.equal('C');
   });
+
+  context('attempt to modify prototype', function() {
+    it('throws an error', function() {
+      assert.throws(
+        () => set({}, '__proto__.foo', 'hacker_attack!'),
+        Error, 'Cannot assign reference to prototype')
+    })
+  })
 });
 
 describe('#decorate', function() {


### PR DESCRIPTION
Disallow assignment to the prototype using `set()`.

This resolves a Prototype Pollution vulnerability. An attacker could
have assigned a value to the target object's prototype, which can modify
how objects behave throughout the entire application.